### PR TITLE
Improve `Music` section

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   root: true,
   extends: [
+    "eslint:recommended",
     "plugin:@typescript-eslint/strict-type-checked",
     "plugin:@typescript-eslint/stylistic-type-checked",
     "next/core-web-vitals",

--- a/app/components/Music.tsx
+++ b/app/components/Music.tsx
@@ -24,28 +24,28 @@ export default function Music() {
   return (
     <Section title="Music" accentColor="secondary">
       <div className="grid grid-cols-1 gap-3.5 @lg/section:grid-cols-2 @lg/section:gap-x-7 @xl/section:gap-x-7.5 @1.5xl/section:gap-x-8 @2xl/section:gap-x-9">
-        <div className="grid grid-rows-[auto_1fr] @container/now-playing @lg/section:order-2">
+        <section className="grid grid-rows-[auto_1fr] @container/now-playing @lg/section:order-2">
           <h3 className={SUBTITLE_STYLE}>Recently Played</h3>
           <NowPlaying />
-        </div>
-        <div className="grid grid-rows-[auto_1fr] @lg/section:order-1">
+        </section>
+        <section className="grid grid-rows-[auto_1fr] @lg/section:order-1">
           <h3 className={SUBTITLE_STYLE}>
             Statistics <small className="pl-0.5">{humanizePeriod(timeRange.statistics)}</small>
           </h3>
           <Statistics period={timeRange.statistics} />
-        </div>
-        <div className="@lg/section:order-3 @lg/section:col-span-full">
+        </section>
+        <section className="@lg/section:order-3 @lg/section:col-span-full">
           <h3 className={SUBTITLE_STYLE}>
             Top Artists <small className="pl-0.5">{humanizePeriod(timeRange.artists)}</small>
           </h3>
           <TopArtistsGrid period={timeRange.artists} />
-        </div>
-        <div className="w-full @lg/section:order-5 @lg/section:col-span-full">
+        </section>
+        <section className="w-full @lg/section:order-5 @lg/section:col-span-full">
           <h3 className={SUBTITLE_STYLE}>
             Top Albums <small className="pl-0.5">{humanizePeriod(timeRange.albums)}</small>
           </h3>
           <TopAlbumsGrid period={timeRange.albums} />
-        </div>
+        </section>
       </div>
     </Section>
   );

--- a/app/components/NowPlaying.tsx
+++ b/app/components/NowPlaying.tsx
@@ -17,13 +17,13 @@ import type { RecentTrack } from "@/lib/types/lastfm";
 
 export default function NowPlaying() {
   const [imageURL, setImageURL] = useState<string>();
-  const {
-    data: track,
-    isLoading,
-    error,
-  } = useSWR<RecentTrack, Error>("/api/music/recent-track", fetcher, {
-    refreshInterval: 30_000, // refresh every 30 seconds
-  });
+  const { data: track, isLoading } = useSWR<RecentTrack, Error>(
+    "/api/music/recent-track",
+    fetcher,
+    {
+      refreshInterval: 30_000, // refresh every 30 seconds
+    },
+  );
 
   useEffect(() => {
     track && setImageURL(track.image);
@@ -31,10 +31,7 @@ export default function NowPlaying() {
 
   if (!track || isLoading) {
     return (
-      <div
-        className="grid grid-cols-[4rem_1fr_2.25rem] items-center gap-2.5 overflow-hidden rounded-md border border-primary/55 p-2 @xs/now-playing:gap-[0.6875rem] @[21.25rem]/now-playing:grid-cols-[4.5rem_1fr_2.25rem] @sm/now-playing:grid-cols-[5rem_1fr_2.25rem] @[340px]/now-playing:gap-3"
-        title={error && "Failed to load"}
-      >
+      <div className="grid grid-cols-[4rem_1fr_2.25rem] items-center gap-2.5 overflow-hidden rounded-md border border-primary/55 p-2 @xs/now-playing:gap-[0.6875rem] @[21.25rem]/now-playing:grid-cols-[4.5rem_1fr_2.25rem] @sm/now-playing:grid-cols-[5rem_1fr_2.25rem] @[340px]/now-playing:gap-3">
         <div className="aspect-square rounded bg-gray-900 ring-1 ring-gray-900"></div>
         <div className="flex flex-col gap-y-2 @[340px]/now-playing:gap-y-[9px]">
           <div className="h-2.5 w-1/2 rounded bg-gray-900 @[340px]/now-playing:h-3"></div>

--- a/app/components/NowPlaying.tsx
+++ b/app/components/NowPlaying.tsx
@@ -17,19 +17,19 @@ import type { RecentTrack } from "@/lib/types/lastfm";
 
 export default function NowPlaying() {
   const [imageURL, setImageURL] = useState<string>();
-  const { data, isLoading, error } = useSWR<RecentTrack, Error>(
-    "/api/music/recent-track",
-    fetcher,
-    {
-      refreshInterval: 30_000, // refresh every 30 seconds
-    },
-  );
+  const {
+    data: track,
+    isLoading,
+    error,
+  } = useSWR<RecentTrack, Error>("/api/music/recent-track", fetcher, {
+    refreshInterval: 30_000, // refresh every 30 seconds
+  });
 
   useEffect(() => {
-    data && setImageURL(data.track.image);
-  }, [data]);
+    track && setImageURL(track.image);
+  }, [track]);
 
-  if (!data || isLoading) {
+  if (!track || isLoading) {
     return (
       <div
         className="grid grid-cols-[4rem_1fr_2.25rem] items-center gap-2.5 overflow-hidden rounded-md border border-primary/55 p-2 @xs/now-playing:gap-[0.6875rem] @[21.25rem]/now-playing:grid-cols-[4.5rem_1fr_2.25rem] @sm/now-playing:grid-cols-[5rem_1fr_2.25rem] @[340px]/now-playing:gap-3"
@@ -47,8 +47,6 @@ export default function NowPlaying() {
       </div>
     );
   }
-
-  const track = data.track;
 
   let dateTime = "";
   let humanizedDateTime = "";

--- a/app/components/Statistics.tsx
+++ b/app/components/Statistics.tsx
@@ -2,21 +2,17 @@ import { IconMicrophone2, IconMusic, IconPlayerPlay, IconVinyl } from "@tabler/i
 import { Suspense } from "react";
 
 import {
-  getRecentTracks,
   getTotalAlbums,
   getTotalArtists,
+  getTotalPlays,
   getTotalTracks,
 } from "@/lib/services/lastfm";
 import dayjs from "@/lib/utils/dayjs";
 import { convertPeriodToDays } from "@/lib/utils/lastfm";
 
-import type { Period, RecentTrack, TotalStats } from "@/lib/types/lastfm";
+import type { Period, TotalStats } from "@/lib/types/lastfm";
 
-type Data<T extends RecentTrack | TotalStats> = {
-  data: Promise<T | null>;
-};
-
-async function Total<T extends RecentTrack | TotalStats>({ data }: Data<T>): Promise<string> {
+async function Total({ data }: { data: Promise<TotalStats | null> }): Promise<string> {
   const result = await data;
   return result?.total ?? "---";
 }
@@ -40,16 +36,16 @@ function Category({
 }
 
 export default function Statistics({ period }: { period: Period }) {
-  let playsData: Promise<RecentTrack | null>;
+  let playsData: Promise<TotalStats | null>;
 
   if (period === "overall") {
-    playsData = getRecentTracks();
+    playsData = getTotalPlays();
   } else {
     const periodInSeconds = dayjs.duration(convertPeriodToDays(period), "days").asSeconds(); // convert period to seconds (e.g. 7day = 604,800 seconds)
     const unixTimestamp = Math.floor(Date.now() / 1000); // get the current Unix timestamp in seconds format (10-digit)
     const beginningTimestamp = unixTimestamp - periodInSeconds;
 
-    playsData = getRecentTracks(beginningTimestamp);
+    playsData = getTotalPlays(beginningTimestamp);
   }
 
   const tracksData = getTotalTracks(period);

--- a/app/components/TopAlbumsGrid.tsx
+++ b/app/components/TopAlbumsGrid.tsx
@@ -5,8 +5,10 @@ import { getTopAlbums } from "@/lib/services/lastfm";
 
 import type { Period } from "@/lib/types/lastfm";
 
-function TopAlbumsSkeleton() {
-  return [...Array<undefined>(6)].map((_, i) => (
+const MAX_ALBUMS_COUNT = 6;
+
+function TopAlbumsSkeleton({ count = MAX_ALBUMS_COUNT }: { count?: number }) {
+  return [...Array<undefined>(count)].map((_, i) => (
     <div
       className="flex items-center gap-x-2.5 pr-2.5 @1.5xl/section:gap-x-3 @1.5xl/section:pr-3"
       key={i}
@@ -21,33 +23,40 @@ function TopAlbumsSkeleton() {
 }
 
 async function TopAlbums({ period }: { period: Period }) {
-  const data = await getTopAlbums(period);
+  const data = await getTopAlbums(period, MAX_ALBUMS_COUNT);
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return <TopAlbumsSkeleton />;
   }
 
-  return data.map((album) => (
-    <div
-      className="flex items-center gap-x-2.5 pr-2.5 @1.5xl/section:gap-x-3 @1.5xl/section:pr-3"
-      key={album.name}
-    >
-      <div className="aspect-square basis-[30%] overflow-hidden rounded bg-gray-900 ring-1 ring-gray-800/75">
-        <Image src={album.image} width={300} height={300} alt="" />
-      </div>
-      <div className="flex basis-[70%] flex-col overflow-hidden tracking-tight @xl/section:gap-y-px">
-        <h4
-          className="truncate text-xs font-medium text-gray-100 @xl/section:text-[13px] @1.5xl/section:text-sm"
-          title={`${album.artist} – ${album.name}`}
+  return (
+    <>
+      {data.map((album) => (
+        <div
+          className="flex items-center gap-x-2.5 pr-2.5 @1.5xl/section:gap-x-3 @1.5xl/section:pr-3"
+          key={album.name}
         >
-          {album.name}
-        </h4>
-        <p className="text-[10px] @xl/section:text-[11px] @1.5xl/section:text-xs">
-          {`${album.playcount} plays`}
-        </p>
-      </div>
-    </div>
-  ));
+          <div className="aspect-square basis-[30%] overflow-hidden rounded bg-gray-900 ring-1 ring-gray-800/75">
+            <Image src={album.image} width={300} height={300} alt="" />
+          </div>
+          <div className="flex basis-[70%] flex-col overflow-hidden tracking-tight @xl/section:gap-y-px">
+            <h4
+              className="truncate text-xs font-medium text-gray-100 @xl/section:text-[13px] @1.5xl/section:text-sm"
+              title={`${album.artist} – ${album.name}`}
+            >
+              {album.name}
+            </h4>
+            <p className="text-[10px] @xl/section:text-[11px] @1.5xl/section:text-xs">
+              {`${album.playcount} plays`}
+            </p>
+          </div>
+        </div>
+      ))}
+      {data.length < MAX_ALBUMS_COUNT && (
+        <TopAlbumsSkeleton count={MAX_ALBUMS_COUNT - data.length} />
+      )}
+    </>
+  );
 }
 
 export default function TopAlbumsGrid({ period }: { period: Period }) {

--- a/app/components/TopAlbumsGrid.tsx
+++ b/app/components/TopAlbumsGrid.tsx
@@ -23,15 +23,15 @@ function TopAlbumsSkeleton({ count = MAX_ALBUMS_COUNT }: { count?: number }) {
 }
 
 async function TopAlbums({ period }: { period: Period }) {
-  const data = await getTopAlbums(period, MAX_ALBUMS_COUNT);
+  const albums = await getTopAlbums(period, MAX_ALBUMS_COUNT);
 
-  if (!data || data.length === 0) {
+  if (!albums || albums.length === 0) {
     return <TopAlbumsSkeleton />;
   }
 
   return (
     <>
-      {data.map((album) => (
+      {albums.map((album) => (
         <div
           className="flex items-center gap-x-2.5 pr-2.5 @1.5xl/section:gap-x-3 @1.5xl/section:pr-3"
           key={album.name}
@@ -52,8 +52,8 @@ async function TopAlbums({ period }: { period: Period }) {
           </div>
         </div>
       ))}
-      {data.length < MAX_ALBUMS_COUNT && (
-        <TopAlbumsSkeleton count={MAX_ALBUMS_COUNT - data.length} />
+      {albums.length < MAX_ALBUMS_COUNT && (
+        <TopAlbumsSkeleton count={MAX_ALBUMS_COUNT - albums.length} />
       )}
     </>
   );

--- a/app/components/TopArtistsGrid.tsx
+++ b/app/components/TopArtistsGrid.tsx
@@ -6,6 +6,8 @@ import { getArtistImage } from "@/lib/services/spotify";
 
 import type { Period } from "@/lib/types/lastfm";
 
+const MAX_ARTISTS_COUNT = 6;
+
 async function ArtistAvatar({ name }: { name: string }) {
   const artistImage = await getArtistImage(name);
 
@@ -18,8 +20,8 @@ async function ArtistAvatar({ name }: { name: string }) {
   );
 }
 
-function TopArtistsSkeleton() {
-  return [...Array<undefined>(6)].map((_, i) => (
+function TopArtistsSkeleton({ count = MAX_ARTISTS_COUNT }: { count?: number }) {
+  return [...Array<undefined>(count)].map((_, i) => (
     <div
       className="grid min-w-[80px] grid-cols-1 gap-y-2 p-2 @xl/section:gap-y-2.5 @xl/section:p-2.5 @1.5xl/section:gap-y-3 @1.5xl/section:p-3 xs:min-w-[96px]"
       key={i}
@@ -34,33 +36,40 @@ function TopArtistsSkeleton() {
 }
 
 async function TopArtists({ period }: { period: Period }) {
-  const data = await getTopArtists(period);
+  const data = await getTopArtists(period, MAX_ARTISTS_COUNT);
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return <TopArtistsSkeleton />;
   }
 
-  return data.map((artist) => (
-    <div
-      className="grid min-w-[80px] grid-cols-1 gap-y-2 p-2 @xl/section:gap-y-2.5 @xl/section:p-2.5 @1.5xl/section:gap-y-3 @1.5xl/section:p-3 xs:min-w-[96px]"
-      key={artist.name.replace(/ /g, "_")} // replace spaces with underscores
-    >
-      <div className="aspect-square overflow-hidden rounded-full bg-gray-900 ring-1 ring-gray-800/75">
-        <Suspense fallback="">
-          <ArtistAvatar name={artist.name} />
-        </Suspense>
-      </div>
-      <div className="flex flex-col text-center tracking-tight @xl/section:gap-y-px">
-        <h4
-          className="truncate text-xs font-medium text-gray-100 @xl/section:text-[13px] @1.5xl/section:text-sm"
-          title={artist.name}
+  return (
+    <>
+      {data.map((artist) => (
+        <div
+          className="grid min-w-[80px] grid-cols-1 gap-y-2 p-2 @xl/section:gap-y-2.5 @xl/section:p-2.5 @1.5xl/section:gap-y-3 @1.5xl/section:p-3 xs:min-w-[96px]"
+          key={artist.name.replace(/ /g, "_")} // replace spaces with underscores
         >
-          {artist.name}
-        </h4>
-        <p className="text-[10px] @xl/section:text-[11px] @1.5xl/section:text-xs">{`${artist.playcount} plays`}</p>
-      </div>
-    </div>
-  ));
+          <div className="aspect-square overflow-hidden rounded-full bg-gray-900 ring-1 ring-gray-800/75">
+            <Suspense fallback="">
+              <ArtistAvatar name={artist.name} />
+            </Suspense>
+          </div>
+          <div className="flex flex-col text-center tracking-tight @xl/section:gap-y-px">
+            <h4
+              className="truncate text-xs font-medium text-gray-100 @xl/section:text-[13px] @1.5xl/section:text-sm"
+              title={artist.name}
+            >
+              {artist.name}
+            </h4>
+            <p className="text-[10px] @xl/section:text-[11px] @1.5xl/section:text-xs">{`${artist.playcount} plays`}</p>
+          </div>
+        </div>
+      ))}
+      {data.length < MAX_ARTISTS_COUNT && (
+        <TopArtistsSkeleton count={MAX_ARTISTS_COUNT - data.length} />
+      )}
+    </>
+  );
 }
 
 export default function TopArtistGrid({ period }: { period: Period }) {

--- a/app/components/TopArtistsGrid.tsx
+++ b/app/components/TopArtistsGrid.tsx
@@ -36,15 +36,15 @@ function TopArtistsSkeleton({ count = MAX_ARTISTS_COUNT }: { count?: number }) {
 }
 
 async function TopArtists({ period }: { period: Period }) {
-  const data = await getTopArtists(period, MAX_ARTISTS_COUNT);
+  const artists = await getTopArtists(period, MAX_ARTISTS_COUNT);
 
-  if (!data || data.length === 0) {
+  if (!artists || artists.length === 0) {
     return <TopArtistsSkeleton />;
   }
 
   return (
     <>
-      {data.map((artist) => (
+      {artists.map((artist) => (
         <div
           className="grid min-w-[80px] grid-cols-1 gap-y-2 p-2 @xl/section:gap-y-2.5 @xl/section:p-2.5 @1.5xl/section:gap-y-3 @1.5xl/section:p-3 xs:min-w-[96px]"
           key={artist.name.replace(/ /g, "_")} // replace spaces with underscores
@@ -65,8 +65,8 @@ async function TopArtists({ period }: { period: Period }) {
           </div>
         </div>
       ))}
-      {data.length < MAX_ARTISTS_COUNT && (
-        <TopArtistsSkeleton count={MAX_ARTISTS_COUNT - data.length} />
+      {artists.length < MAX_ARTISTS_COUNT && (
+        <TopArtistsSkeleton count={MAX_ARTISTS_COUNT - artists.length} />
       )}
     </>
   );

--- a/lib/services/lastfm/user/get-recent-tracks.ts
+++ b/lib/services/lastfm/user/get-recent-tracks.ts
@@ -2,22 +2,20 @@ import { z } from "zod";
 
 import { generateEndpoint } from "@/lib/utils/lastfm";
 
-import type { LastfmParams, Limit, RecentTrack, Timestamp } from "@/lib/types/lastfm";
+import type { LastfmParams, Limit, RecentTrack, Timestamp, TotalStats } from "@/lib/types/lastfm";
 
 const RecentTracksSchema = z.object({
   recenttracks: z.object({
-    track: z
-      .array(
-        z.object({
-          artist: z.object({ name: z.string() }),
-          date: z.object({ uts: z.string() }).optional(),
-          name: z.string(),
-          image: z.array(z.object({ "#text": z.string().url() })).length(4),
-          album: z.object({ "#text": z.string() }),
-          loved: z.enum(["0", "1"]),
-        }),
-      )
-      .nonempty(),
+    track: z.array(
+      z.object({
+        artist: z.object({ name: z.string() }),
+        date: z.object({ uts: z.string() }).optional(),
+        name: z.string(),
+        image: z.array(z.object({ "#text": z.string().url() })).length(4),
+        album: z.object({ "#text": z.string() }),
+        loved: z.enum(["0", "1"]),
+      }),
+    ),
     "@attr": z.object({ total: z.string() }),
   }),
 });
@@ -32,9 +30,9 @@ export async function getRecentTracks(
 ): Promise<RecentTrack | null> {
   const params: LastfmParams = {
     method: "user.getrecenttracks",
-    limit,
     from,
     extended: "1",
+    limit,
   };
 
   const response = await fetch(generateEndpoint(params));
@@ -49,7 +47,7 @@ export async function getRecentTracks(
 
   const { artist, image, album, name, loved } = firstTrack;
   const timestamp = firstTrack.date !== undefined && +firstTrack.date.uts;
-  const track: RecentTrack["track"] = {
+  const track: RecentTrack = {
     name,
     artist: artist.name,
     album: album["#text"],
@@ -58,7 +56,26 @@ export async function getRecentTracks(
     loved: loved === "1",
   };
 
-  const total: RecentTrack["total"] = recenttracks["@attr"].total;
+  return track;
+}
 
-  return { track, total };
+/**
+ * @param from - Only fetch results after this time, in Unix timestamp format (seconds, 10-digit).
+ */
+export async function getTotalPlays(from?: Timestamp): Promise<TotalStats | null> {
+  const params: LastfmParams = {
+    method: "user.getrecenttracks",
+    from,
+    extended: "1",
+    limit: 1,
+  };
+
+  const response = await fetch(generateEndpoint(params), { cache: "no-store" });
+  const result = RecentTracksSchema.safeParse(await response.json());
+
+  if (!result.success) return null;
+
+  const { recenttracks } = result.data;
+
+  return { total: recenttracks["@attr"].total };
 }

--- a/lib/services/lastfm/user/get-top-albums.ts
+++ b/lib/services/lastfm/user/get-top-albums.ts
@@ -6,25 +6,23 @@ import type { LastfmParams, Limit, Period, TopAlbums, TotalStats } from "@/lib/t
 
 const TopAlbumsSchema = z.object({
   topalbums: z.object({
-    album: z
-      .array(
-        z.object({
-          artist: z.object({ name: z.string() }),
-          image: z.array(z.object({ "#text": z.string().url() })).length(4),
-          playcount: z.string(),
-          name: z.string(),
-        }),
-      )
-      .nonempty(),
+    album: z.array(
+      z.object({
+        artist: z.object({ name: z.string() }),
+        image: z.array(z.object({ "#text": z.string().url() })).length(4),
+        playcount: z.string(),
+        name: z.string(),
+      }),
+    ),
     "@attr": z.object({ total: z.string() }),
   }),
 });
 
 /**
  * @param period - The time period over which to retrieve top albums for.
- * @param limit - The number of results to fetch. Defaults to 6. Maximum is 10.
+ * @param limit - The number of albums to fetch.
  */
-export async function getTopAlbums(period: Period, limit: Limit = 6): Promise<TopAlbums | null> {
+export async function getTopAlbums(period: Period, limit: Limit): Promise<TopAlbums | null> {
   const params: LastfmParams = {
     method: "user.gettopalbums",
     period,

--- a/lib/services/lastfm/user/get-top-artists.ts
+++ b/lib/services/lastfm/user/get-top-artists.ts
@@ -6,23 +6,21 @@ import type { LastfmParams, Limit, Period, TopArtists, TotalStats } from "@/lib/
 
 const TopArtistsSchema = z.object({
   topartists: z.object({
-    artist: z
-      .array(
-        z.object({
-          name: z.string(),
-          playcount: z.string(),
-        }),
-      )
-      .nonempty(),
+    artist: z.array(
+      z.object({
+        name: z.string(),
+        playcount: z.string(),
+      }),
+    ),
     "@attr": z.object({ total: z.string() }),
   }),
 });
 
 /**
  * @param period - The time period over which to retrieve top artists for.
- * @param limit - The number of results to fetch. Defaults to 6. Maximum is 10.
+ * @param limit - The number of artists to fetch.
  */
-export async function getTopArtists(period: Period, limit: Limit = 6): Promise<TopArtists | null> {
+export async function getTopArtists(period: Period, limit: Limit): Promise<TopArtists | null> {
   const params: LastfmParams = {
     method: "user.gettopartists",
     period,

--- a/lib/services/lastfm/user/get-top-tracks.ts
+++ b/lib/services/lastfm/user/get-top-tracks.ts
@@ -6,25 +6,23 @@ import type { LastfmParams, Limit, Period, TopTracks, TotalStats } from "@/lib/t
 
 const TopTracksSchema = z.object({
   toptracks: z.object({
-    track: z
-      .array(
-        z.object({
+    track: z.array(
+      z.object({
+        name: z.string(),
+        artist: z.object({
           name: z.string(),
-          artist: z.object({
-            name: z.string(),
-          }),
         }),
-      )
-      .nonempty(),
+      }),
+    ),
     "@attr": z.object({ total: z.string() }),
   }),
 });
 
 /**
  * @param period - The time period over which to retrieve top tracks for.
- * @param limit - The number of results to fetch. Defaults to 6. Maximum is 10.
+ * @param limit - The number of tracks to fetch.
  */
-export async function getTopTracks(period: Period, limit: Limit = 6): Promise<TopTracks | null> {
+export async function getTopTracks(period: Period, limit: Limit): Promise<TopTracks | null> {
   const params: LastfmParams = {
     method: "user.gettoptracks",
     period,

--- a/lib/types/lastfm.ts
+++ b/lib/types/lastfm.ts
@@ -7,7 +7,7 @@ export type Timestamp = number;
 type MethodParams =
   | {
       method: "user.getrecenttracks";
-      from?: Timestamp;
+      from: Timestamp | undefined;
       extended: "1";
     }
   | {
@@ -37,16 +37,11 @@ export type Artist = {
   image_url?: string;
 };
 
-export type Total = string;
-
-export type RecentTrack = {
-  track: Track & {
-    album: string;
-    image: string;
-    timestamp?: Timestamp;
-    loved: boolean;
-  };
-  total: Total;
+export type RecentTrack = Track & {
+  album: string;
+  image: string;
+  timestamp?: Timestamp;
+  loved: boolean;
 };
 
 export type TopTracks = Track[];
@@ -55,4 +50,4 @@ export type TopAlbums = Album[];
 
 export type TopArtists = Artist[];
 
-export type TotalStats = { total: Total };
+export type TotalStats = { total: string };

--- a/lib/utils/lastfm.ts
+++ b/lib/utils/lastfm.ts
@@ -10,11 +10,12 @@ export function generateEndpoint(params: LastfmParams): string {
   const API_KEY = env.LASTFM_API_KEY;
   const USERNAME = env.LASTFM_USERNAME;
 
-  const stringifyParams = Object.entries(params)
-    .map(([key, val]) => typeof val !== "undefined" && `${key}=${val}`)
+  const paramsQueryString = Object.entries(params)
+    .filter(([, val]) => val !== undefined)
+    .map(([key, val]) => `${key}=${val}`)
     .join("&");
 
-  return `${API_ROOT}?${stringifyParams}&user=${USERNAME}&api_key=${API_KEY}&format=json`;
+  return `${API_ROOT}?${paramsQueryString}&user=${USERNAME}&api_key=${API_KEY}&format=json`;
 }
 
 export function humanizePeriod(period: Period): string {


### PR DESCRIPTION
## Changes

- Fill empty spots in top artists and top albums sub-section with skeletons when the fetch results is less than the required amount
- Remove `noempty()` on arrays of Last.fm API validation schemas to reflect the fact that the APIs may return empty arrays