### PR TITLE
Add local ID acquisition for more accurate artist image retrieval from Spotify API

### DIFF
--- a/lib/data/artists.json
+++ b/lib/data/artists.json
@@ -1,0 +1,314 @@
+[
+  {
+    "name": "2NE1",
+    "id": "1l0mKo96Jh9HVYONcRl3Yp"
+  },
+  {
+    "name": "5 Seconds of Summer",
+    "id": "5Rl15oVamLq7FbSb0NNBNy"
+  },
+  {
+    "name": "Ariana Grande",
+    "id": "66CXWjxzNUsdJxJ2JdwvnR"
+  },
+  {
+    "name": "Ava Max",
+    "id": "4npEfmQ6YuiwW1GpUmaq3F"
+  },
+  {
+    "name": "BTS",
+    "id": "3Nrfpe0tUJi4K4DXYWgMUX"
+  },
+  {
+    "name": "Bad Suns",
+    "id": "0YhUSm86okLWldQVwJkLlP"
+  },
+  {
+    "name": "Beast",
+    "id": "1Pr9gT0veB2tgcisQeIGoC"
+  },
+  {
+    "name": "Bicep",
+    "id": "73A3bLnfnz5BoQjb4gNCga"
+  },
+  {
+    "name": "Bleachers",
+    "id": "2eam0iDomRHGBypaDQLwWI"
+  },
+  {
+    "name": "Blossoms",
+    "id": "22RISwgVJyZu9lpqAcv1F5"
+  },
+  {
+    "name": "Boa",
+    "id": "4muJrGMndyYWqZtfk8OWy4"
+  },
+  {
+    "name": "Brinley Spears",
+    "id": "26dSoYclwsYLMAKD3tpOr4"
+  },
+  {
+    "name": "BØRNS",
+    "id": "1KP6TWI40m7p3QBTU6u2xo"
+  },
+  {
+    "name": "C418",
+    "id": "4uFZsG1vXrPcvnZ4iSQyrx"
+  },
+  {
+    "name": "Cage the Elephant",
+    "id": "26T3LtbuGT1Fu9m0eRq5X3"
+  },
+  {
+    "name": "Capital Cities",
+    "id": "4gwpcMTbLWtBUlOijbVpuu"
+  },
+  {
+    "name": "Charlie Puth",
+    "id": "6VuMaDnrHyPL1p4EHjYLi7"
+  },
+  {
+    "name": "Climie Fisher",
+    "id": "3bpvhFSIErguVNQUiutctF"
+  },
+  {
+    "name": "Coin",
+    "id": "0ZxZlO7oWCSYMXhehpyMvE"
+  },
+  {
+    "name": "Coldplay",
+    "id": "4gzpq5DPGxSnKTe4SA8HAU"
+  },
+  {
+    "name": "Daft Punk",
+    "id": "4tZwfgrHOc3mvqYlEYSvVi"
+  },
+  {
+    "name": "Dayglow",
+    "id": "6eJa3zG1QZLRB3xgRuyxbm"
+  },
+  {
+    "name": "Depeche Mode",
+    "id": "762310PdDnwsDxAQxzQkfX"
+  },
+  {
+    "name": "Dua Lipa",
+    "id": "6M2wZ9GZgrQXHCFfjv46we"
+  },
+  {
+    "name": "Empire of the Sun",
+    "id": "67hb7towEyKvt5Z8Bx306c"
+  },
+  {
+    "name": "Fitz and the Tantrums",
+    "id": "4AcHt3JxKy59IX7JNNlZn4"
+  },
+  {
+    "name": "Fleetwood Mac",
+    "id": "08GQAI4eElDnROBrJRGE0X"
+  },
+  {
+    "name": "Flor",
+    "id": "0szWPxzzE8DVEfXFRCLBUb"
+  },
+  {
+    "name": "Foster the People",
+    "id": "7gP3bB2nilZXLfPHJhMdvc"
+  },
+  {
+    "name": "Glass Animals",
+    "id": "4yvcSjfu4PC0CYQyLy4wSq"
+  },
+  {
+    "name": "Hippo Campus",
+    "id": "1btWGBz4Uu1HozTwb2Lm8A"
+  },
+  {
+    "name": "Hunny",
+    "id": "5rebfYbZVIhbRVcRKWVOAh"
+  },
+  {
+    "name": "In the Valley Below",
+    "id": "4WQXRya5np83C21wifjNp9"
+  },
+  {
+    "name": "Joan",
+    "id": "3HXLY1sNXIxHfulrjPiRf5"
+  },
+  {
+    "name": "Johnny Hates Jazz",
+    "id": "6zpPKMhpOoG646kJgZ7RKf"
+  },
+  {
+    "name": "Kraftwerk",
+    "id": "0dmPX6ovclgOy8WWJaFEUU"
+  },
+  {
+    "name": "Lady Gaga",
+    "id": "1HY2Jd0NmPuamShAr6KMms"
+  },
+  {
+    "name": "Lany",
+    "id": "49tQo2QULno7gxHutgccqF"
+  },
+  {
+    "name": "Lauv",
+    "id": "5JZ7CnR6gTvEMKX4g70Amv"
+  },
+  {
+    "name": "Lorde",
+    "id": "163tK9Wjr9P9DmM0AVK7lm"
+  },
+  {
+    "name": "MAMAMOO",
+    "id": "0XATRDCYuuGhk0oE7C0o5G"
+  },
+  {
+    "name": "Madonna",
+    "id": "6tbjWDEIzxoDsBA1FuhfPW"
+  },
+  {
+    "name": "Maroon 5",
+    "id": "04gDigrS5kc9YWfZHwBETP"
+  },
+  {
+    "name": "New Order",
+    "id": "0yNLKJebCb8Aueb54LYya3"
+  },
+  {
+    "name": "Nicki Minaj",
+    "id": "0hCNtLu0JehylgoiP8L4Gh"
+  },
+  {
+    "name": "OneRepublic",
+    "id": "5Pwc4xIPtQLFEnJriah9YJ"
+  },
+  {
+    "name": "Paco Versailles",
+    "id": "5VptPtXbT0T4imW6GcobiW"
+  },
+  {
+    "name": "Passion Pit",
+    "id": "7gjAu1qr5C2grXeQFFOGeh"
+  },
+  {
+    "name": "Pet Shop Boys",
+    "id": "2ycnb8Er79LoH2AsR5ldjh"
+  },
+  {
+    "name": "Phoenix",
+    "id": "1xU878Z1QtBldR7ru9owdU"
+  },
+  {
+    "name": "Roosevelt",
+    "id": "4AQrqVz6BYwy29iMxcGtx7"
+  },
+  {
+    "name": "S.H.E",
+    "id": "2lWShxOL8iTlI0pmtVKvEh"
+  },
+  {
+    "name": "SHINee",
+    "id": "2hRQKC0gqlZGPrmUKbcchR"
+  },
+  {
+    "name": "SISTAR",
+    "id": "2wTLheTmMcFCA4hdY8hZJP"
+  },
+  {
+    "name": "SS501",
+    "id": "6rmMpoeu2SIV4OLURCOn2e"
+  },
+  {
+    "name": "STRFKR",
+    "id": "2Tz1DTzVJ5Gyh8ZwVr6ekU"
+  },
+  {
+    "name": "Sam Smith",
+    "id": "2wY79sveU1sp5g7SokKOiI"
+  },
+  {
+    "name": "Sheppard",
+    "id": "6VxCmtR7S3yz4vnzsJqhSV"
+  },
+  {
+    "name": "Sir Sly",
+    "id": "3DFoVPonoAAt4EZ1FEI8ue"
+  },
+  {
+    "name": "St. Lucia",
+    "id": "5WId4o5jdGVhptNU0uqKxu"
+  },
+  {
+    "name": "Starfucker",
+    "id": "2Tz1DTzVJ5Gyh8ZwVr6ekU"
+  },
+  {
+    "name": "Tame Impala",
+    "id": "5INjqkS1o8h1imAzPqGZBb"
+  },
+  {
+    "name": "Taylor Swift",
+    "id": "06HL4z0CvFAxyc27GXpf02"
+  },
+  {
+    "name": "Tears for Fears",
+    "id": "4bthk9UfsYUYdcFyqxmSUU"
+  },
+  {
+    "name": "The 1975",
+    "id": "3mIj9lX2MWuHmhNCA7LSCW"
+  },
+  {
+    "name": "The Neighbourhood",
+    "id": "77SW9BnxLY8rJ0RciFqkHh"
+  },
+  {
+    "name": "The Weeknd",
+    "id": "1Xyo4u8uXC1ZmMpatF05PJ"
+  },
+  {
+    "name": "Tokio Hotel",
+    "id": "46aNfN89JrOQTCy97GoCHa"
+  },
+  {
+    "name": "Troye Sivan",
+    "id": "3WGpXCj9YhhfX11TToZcXP"
+  },
+  {
+    "name": "Two Door Cinema Club",
+    "id": "536BYVgOnRky0xjsPT96zl"
+  },
+  {
+    "name": "Vacation Manor",
+    "id": "6lcBiGiT3dlyDMjBBtfyfS"
+  },
+  {
+    "name": "Wallows",
+    "id": "0NIPkIjTV8mB795yEIiPYL"
+  },
+  {
+    "name": "Yazoo",
+    "id": "1G1mX30GpUJqOr1QU2eBSs"
+  },
+  {
+    "name": "courtship.",
+    "id": "2OK16hAFRHoJiFZKeZe8A8"
+  },
+  {
+    "name": "張韶涵",
+    "id": "4txug0T3vYc9p20tuhfCUa"
+  },
+  {
+    "name": "東方神起",
+    "id": "6nVMMEywS5Y4tsHPKx1nIo"
+  },
+  {
+    "name": "소녀시대",
+    "id": "0Sadg1vgvaPqGTOjxu0N6c"
+  },
+  {
+    "name": "신화",
+    "id": "0jVvkFPa6YbFXQ3Qmhita0"
+  }
+]


### PR DESCRIPTION
This commit introduces the ability to skip the search step and directly acquire artist IDs locally. This change aims to improve the accuracy of artist image acquisition from the Spotify API. The `getArtistSpotifyID` function is used to find the artist's ID from the `topArtists` array. If the ID is found, it is used to fetch the artist's image directly. If not, the existing search method is used as a fallback.