### PR TITLE
Add on-demand revalidation for `Bookmarks` section

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,6 @@
+# Secret token for On-demand Revalidation
+DASHBOARD_BOOKMARKS_REVALIDATION_TOKEN=
+
 # Last.fm API
 LASTFM_USERNAME=
 LASTFM_API_KEY=

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,61 @@
+/**
+ * This is the revalidation route handler for On-Demand Revalidation.
+ *
+ * @example
+ * GET `https://<your-site.com>/api/revalidate?tag=<valid-tag>&secret=<secret-token>`
+ */
+
+import { revalidateTag } from "next/cache";
+
+import { env } from "@/app/env.mjs";
+
+import type { NextRequest } from "next/server";
+
+export function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const secret = searchParams.get("secret");
+  const tag = searchParams.get("tag");
+
+  if (!secret || !tag)
+    return new Response(
+      JSON.stringify({
+        revalidated: false,
+        message: "Missing secret and/or tag parameter",
+        now: Date.now(),
+      }),
+      { status: 400 },
+    );
+
+  // Check for secret to confirm this is a valid request
+  if (secret !== env.DASHBOARD_BOOKMARKS_REVALIDATION_TOKEN) {
+    return new Response(
+      JSON.stringify({
+        revalidated: false,
+        message: "Invalid secret token",
+        now: Date.now(),
+      }),
+      { status: 401 },
+    );
+  }
+
+  try {
+    revalidateTag(tag);
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        revalidated: false,
+        message: (error as Error).message,
+        now: Date.now(),
+      }),
+      { status: 400 },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      revalidated: true,
+      message: `Successfully revalidated ${tag} tag`,
+      now: Date.now(),
+    }),
+  );
+}

--- a/app/env.mjs
+++ b/app/env.mjs
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
+    DASHBOARD_BOOKMARKS_REVALIDATION_TOKEN: z.string().min(1),
     LASTFM_USERNAME: z.string().min(1),
     LASTFM_API_KEY: z.string().min(1),
     SPOTIFY_CLIENT_ID: z.string().min(1),

--- a/lib/services/raindrop.ts
+++ b/lib/services/raindrop.ts
@@ -30,7 +30,7 @@ export async function getBookmarks(limit: Limit): Promise<Bookmarks | null> {
     headers: {
       Authorization: `Bearer ${bearerToken}`,
     },
-    cache: "no-store",
+    next: { tags: ["bookmarks"] }, // add tag for on-demand revalidation
   });
   const result = BookmarksSchema.safeParse(await response.json());
 


### PR DESCRIPTION
## Changes

- Add secret token for on-demand revalidation of bookmarks
- Add `revalidate` route handler that purge cached data with a specific cache tag using the `revalidateTag` function
- Add `bookmarks` tag to the `getBookmarks()` fetch request