### PR TITLE
Improve top artists

### DIFF
--- a/app/components/TopArtistsGrid.tsx
+++ b/app/components/TopArtistsGrid.tsx
@@ -59,7 +59,7 @@ async function TopArtists({ period }: { period: Period }) {
           </div>
           <div className="flex flex-col text-center tracking-tight @xl/section:gap-y-px">
             <h4
-              className="truncate text-xs font-medium text-gray-100 @xl/section:text-[13px] @[39rem]/section:text-sm"
+              className="truncate text-xs font-medium text-gray-100 select-all @xl/section:text-[13px] @[39rem]/section:text-sm"
               title={artist.name}
             >
               {artist.name}

--- a/lib/data/artists.json
+++ b/lib/data/artists.json
@@ -8,16 +8,16 @@
     "id": "5Rl15oVamLq7FbSb0NNBNy"
   },
   {
+    "name": "Argonaut & Wasp",
+    "id": "5FE0B5zV9y7T5OzkiDkBG8"
+  },
+  {
     "name": "Ariana Grande",
     "id": "66CXWjxzNUsdJxJ2JdwvnR"
   },
   {
     "name": "Ava Max",
     "id": "4npEfmQ6YuiwW1GpUmaq3F"
-  },
-  {
-    "name": "BTS",
-    "id": "3Nrfpe0tUJi4K4DXYWgMUX"
   },
   {
     "name": "Bad Suns",
@@ -44,12 +44,16 @@
     "id": "4muJrGMndyYWqZtfk8OWy4"
   },
   {
-    "name": "Brinley Spears",
+    "name": "BØRNS",
+    "id": "1KP6TWI40m7p3QBTU6u2xo"
+  },
+  {
+    "name": "Britney Spears",
     "id": "26dSoYclwsYLMAKD3tpOr4"
   },
   {
-    "name": "BØRNS",
-    "id": "1KP6TWI40m7p3QBTU6u2xo"
+    "name": "BTS",
+    "id": "3Nrfpe0tUJi4K4DXYWgMUX"
   },
   {
     "name": "C418",
@@ -78,6 +82,10 @@
   {
     "name": "Coldplay",
     "id": "4gzpq5DPGxSnKTe4SA8HAU"
+  },
+  {
+    "name": "courtship.",
+    "id": "2OK16hAFRHoJiFZKeZe8A8"
   },
   {
     "name": "Daft Punk",
@@ -160,12 +168,12 @@
     "id": "163tK9Wjr9P9DmM0AVK7lm"
   },
   {
-    "name": "MAMAMOO",
-    "id": "0XATRDCYuuGhk0oE7C0o5G"
-  },
-  {
     "name": "Madonna",
     "id": "6tbjWDEIzxoDsBA1FuhfPW"
+  },
+  {
+    "name": "MAMAMOO",
+    "id": "0XATRDCYuuGhk0oE7C0o5G"
   },
   {
     "name": "Maroon 5",
@@ -208,22 +216,6 @@
     "id": "2lWShxOL8iTlI0pmtVKvEh"
   },
   {
-    "name": "SHINee",
-    "id": "2hRQKC0gqlZGPrmUKbcchR"
-  },
-  {
-    "name": "SISTAR",
-    "id": "2wTLheTmMcFCA4hdY8hZJP"
-  },
-  {
-    "name": "SS501",
-    "id": "6rmMpoeu2SIV4OLURCOn2e"
-  },
-  {
-    "name": "STRFKR",
-    "id": "2Tz1DTzVJ5Gyh8ZwVr6ekU"
-  },
-  {
     "name": "Sam Smith",
     "id": "2wY79sveU1sp5g7SokKOiI"
   },
@@ -232,8 +224,24 @@
     "id": "6VxCmtR7S3yz4vnzsJqhSV"
   },
   {
+    "name": "SHINee",
+    "id": "2hRQKC0gqlZGPrmUKbcchR"
+  },
+  {
     "name": "Sir Sly",
     "id": "3DFoVPonoAAt4EZ1FEI8ue"
+  },
+  {
+    "name": "SISTAR",
+    "id": "2wTLheTmMcFCA4hdY8hZJP"
+  },
+  {
+    "name": "Sports",
+    "id": "4AGNJdJiVltImYk1UTLE0K"
+  },
+  {
+    "name": "SS501",
+    "id": "6rmMpoeu2SIV4OLURCOn2e"
   },
   {
     "name": "St. Lucia",
@@ -241,6 +249,10 @@
   },
   {
     "name": "Starfucker",
+    "id": "2Tz1DTzVJ5Gyh8ZwVr6ekU"
+  },
+  {
+    "name": "STRFKR",
     "id": "2Tz1DTzVJ5Gyh8ZwVr6ekU"
   },
   {
@@ -268,6 +280,10 @@
     "id": "1Xyo4u8uXC1ZmMpatF05PJ"
   },
   {
+    "name": "The Wombats",
+    "id": "0Ya43ZKWHTKkAbkoJJkwIB"
+  },
+  {
     "name": "Tokio Hotel",
     "id": "46aNfN89JrOQTCy97GoCHa"
   },
@@ -292,8 +308,12 @@
     "id": "1G1mX30GpUJqOr1QU2eBSs"
   },
   {
-    "name": "courtship.",
-    "id": "2OK16hAFRHoJiFZKeZe8A8"
+    "name": "소녀시대",
+    "id": "0Sadg1vgvaPqGTOjxu0N6c"
+  },
+  {
+    "name": "신화",
+    "id": "0jVvkFPa6YbFXQ3Qmhita0"
   },
   {
     "name": "張韶涵",
@@ -302,13 +322,5 @@
   {
     "name": "東方神起",
     "id": "6nVMMEywS5Y4tsHPKx1nIo"
-  },
-  {
-    "name": "소녀시대",
-    "id": "0Sadg1vgvaPqGTOjxu0N6c"
-  },
-  {
-    "name": "신화",
-    "id": "0jVvkFPa6YbFXQ3Qmhita0"
   }
 ]


### PR DESCRIPTION
## Changes

- Optimize artist ID lookup with precomputed `Map` for faster artist name -> Spotify ID resolution
- Sort `artists` array by name in ascending order
- Add `user-select: all` to allow full selection of truncated top artist names in `Music` section